### PR TITLE
Updating dependencies and give a sample usage

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -14,18 +14,18 @@
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);$(OS)</DefineConstants>
     <NoWarn>$(NoWarn);NU5105</NoWarn>
-    <PackageVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(Version)-$(BUILD_BUILDNUMBER)</PackageVersion>
+    <PackageVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(Version).$(BUILD_BUILDNUMBER)</PackageVersion>
   </PropertyGroup>
 
   <!-- Package versions for package references across all projects -->
   <ItemGroup>
-    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="3.3.1-beta3-final" />
+    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="3.3.1" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.3.0-preview-20190828-03" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" />
     <PackageReference Update="NUnit" Version="3.12.0" />
     <PackageReference Update="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Update="System.CommandLine.Experimental" Version="0.3.0-alpha.19405.1" />
-    <PackageReference Update="TerraFX.Utilities" Version="0.1.0-alpha-20190917.1" />
+    <PackageReference Update="TerraFX.Utilities" Version="0.1.0-alpha.20191011.2" />
   </ItemGroup>
 
 </Project>

--- a/sources/Optimizer/Program.cs
+++ b/sources/Optimizer/Program.cs
@@ -1,8 +1,13 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using System.Threading.Tasks;
+using TerraFX.Optimization.CodeAnalysis;
 
 namespace TerraFX.Optimization
 {
@@ -22,7 +27,42 @@ namespace TerraFX.Optimization
         {
             int exitCode = 0;
 
+            using var peStream = File.OpenRead("TerraFX.Optimization.dll");
+            using var peReader = new PEReader(peStream);
 
+            var metadataReader = peReader.GetMetadataReader();
+
+            foreach (var methodDefinitionHandle in metadataReader.MethodDefinitions)
+            {
+                var methodDefinition = metadataReader.GetMethodDefinition(methodDefinitionHandle);
+
+                var typeHandle = methodDefinition.GetDeclaringType();
+                var typeDefinition = metadataReader.GetTypeDefinition(typeHandle);
+
+                var namespaceName = metadataReader.GetString(typeDefinition.Namespace);
+                var typeName = metadataReader.GetString(typeDefinition.Name);
+                var methodName = metadataReader.GetString(methodDefinition.Name);
+
+                Console.WriteLine($"{namespaceName}.{typeName}.{methodName}");
+
+                var methodBody = peReader.GetMethodBody(methodDefinition.RelativeVirtualAddress);
+                var flowgraph = FlowGraph.Decode(metadataReader, methodBody);
+
+                for (int i = 0; i < flowgraph.Blocks.Count; i++)
+                {
+                    Console.WriteLine($"  BB{i:X2}");
+                    var block = flowgraph.Blocks[i];
+                    
+                    for (var instruction = block.FirstInstruction; instruction != block.LastInstruction; instruction = instruction.Next!)
+                    {
+                        Console.Write("    ");
+                        Console.WriteLine(instruction);
+                    }
+
+                    Console.Write("    ");
+                    Console.WriteLine(block.LastInstruction);
+                }
+            }
 
             return exitCode;
         }

--- a/sources/Optimizer/TerraFX.Optimizer.csproj
+++ b/sources/Optimizer/TerraFX.Optimizer.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
 
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine.Experimental" />
-    <PackageReference Include="TerraFX.Utilities" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This updates the dependencies to their latest version and also changes the main program to just print basic blocks for `TerraFX.Optimization.dll` as an example usage.