### PR TITLE
Updating Operand.ToString to handle more types

### DIFF
--- a/sources/Optimization/CodeAnalysis/BasicBlock.cs
+++ b/sources/Optimization/CodeAnalysis/BasicBlock.cs
@@ -87,20 +87,20 @@ namespace TerraFX.Optimization.CodeAnalysis
 
             var firstInstruction = FirstInstruction;
 
-            builder.Append("IL_");
+            _ = builder.Append("IL_");
             var offset = firstInstruction.GetOffset();
-            builder.Append(offset.ToString("X4"));
+            _ = builder.Append(offset.ToString("X4"));
 
             var lastInstruction = LastInstruction;
 
             if (lastInstruction != firstInstruction)
             {
-                builder.Append(',');
-                builder.Append(' ');
+                _ = builder.Append(',');
+                _ = builder.Append(' ');
 
-                builder.Append("IL_");
+                _ = builder.Append("IL_");
                 offset = lastInstruction.GetOffset();
-                builder.Append(offset.ToString("X4"));
+                _ = builder.Append(offset.ToString("X4"));
             }
 
             return builder.ToString();
@@ -115,7 +115,7 @@ namespace TerraFX.Optimization.CodeAnalysis
             var visitedBlocks = new HashSet<BasicBlock>();
             var pendingBlocks = new Queue<BasicBlock>();
 
-            visitedBlocks.Add(this);
+            _ = visitedBlocks.Add(this);
             pendingBlocks.Enqueue(this);
 
             do
@@ -127,7 +127,7 @@ namespace TerraFX.Optimization.CodeAnalysis
                 {
                     if (visitedBlocks.Contains(child) == false)
                     {
-                        visitedBlocks.Add(child);
+                        _ = visitedBlocks.Add(child);
                         pendingBlocks.Enqueue(child);
                     }
                 }
@@ -144,7 +144,7 @@ namespace TerraFX.Optimization.CodeAnalysis
             var visitedBlocks = new HashSet<BasicBlock>();
             var pendingBlocks = new Queue<BasicBlock>();
 
-            visitedBlocks.Add(this);
+            _ = visitedBlocks.Add(this);
             pendingBlocks.Enqueue(this);
 
             do
@@ -156,7 +156,7 @@ namespace TerraFX.Optimization.CodeAnalysis
                 {
                     if (visitedBlocks.Contains(child) == false)
                     {
-                        visitedBlocks.Add(child);
+                        _ = visitedBlocks.Add(child);
                         pendingBlocks.Enqueue(child);
                     }
                 }
@@ -173,7 +173,7 @@ namespace TerraFX.Optimization.CodeAnalysis
             var visitedBlocks = new HashSet<BasicBlock>();
             var pendingBlocks = new Stack<BasicBlock>();
 
-            visitedBlocks.Add(this);
+            _ = visitedBlocks.Add(this);
             pendingBlocks.Push(this);
 
             do
@@ -185,7 +185,7 @@ namespace TerraFX.Optimization.CodeAnalysis
                 {
                     if (visitedBlocks.Contains(child) == false)
                     {
-                        visitedBlocks.Add(child);
+                        _ = visitedBlocks.Add(child);
                         pendingBlocks.Push(child);
                     }
                 }
@@ -202,7 +202,7 @@ namespace TerraFX.Optimization.CodeAnalysis
             var visitedBlocks = new HashSet<BasicBlock>();
             var pendingBlocks = new Stack<BasicBlock>();
 
-            visitedBlocks.Add(this);
+            _ = visitedBlocks.Add(this);
             pendingBlocks.Push(this);
 
             do
@@ -214,7 +214,7 @@ namespace TerraFX.Optimization.CodeAnalysis
                 {
                     if (visitedBlocks.Contains(child) == false)
                     {
-                        visitedBlocks.Add(child);
+                        _ = visitedBlocks.Add(child);
                         pendingBlocks.Push(child);
                     }
                 }

--- a/sources/Optimization/CodeAnalysis/FlowGraph.cs
+++ b/sources/Optimization/CodeAnalysis/FlowGraph.cs
@@ -109,8 +109,8 @@ namespace TerraFX.Optimization.CodeAnalysis
                                 // to add the existing block as a child of the current block and return
                                 // false so that we stop processing this sequence.
 
-                                currentBlock._children.Add(childBlock);
-                                childBlock._parents.Add(currentBlock);
+                                _ = currentBlock._children.Add(childBlock);
+                                _ = childBlock._parents.Add(currentBlock);
 
                                 instruction = null;
                             }
@@ -192,7 +192,7 @@ namespace TerraFX.Optimization.CodeAnalysis
                     {
                         // Ensure the next instruction has already been processed or is part of the pending
                         // block list so that we can properly track dead/dangling code for later cleanup.
-                        ProcessFirstInstruction(nextInstruction, instructionMap, firstInstructionMap, pendingBlocks);
+                        _ = ProcessFirstInstruction(nextInstruction, instructionMap, firstInstructionMap, pendingBlocks);
                     }
                 }
             }
@@ -217,8 +217,8 @@ namespace TerraFX.Optimization.CodeAnalysis
             {
                 var childBlock = ProcessFirstInstruction(firstInstruction, instructionMap, firstInstructionMap, pendingBlocks);
 
-                parentBlock._children.Add(childBlock);
-                childBlock._parents.Add(parentBlock);
+                _ = parentBlock._children.Add(childBlock);
+                _ = childBlock._parents.Add(parentBlock);
             }
 
             static BasicBlock ProcessFirstInstruction(Instruction firstInstruction, Dictionary<Instruction, BasicBlock> instructionMap, Dictionary<Instruction, BasicBlock> firstInstructionMap, Stack<BasicBlock> pendingBlocks)
@@ -250,8 +250,8 @@ namespace TerraFX.Optimization.CodeAnalysis
                     targetBlock._children = childBlock._children;
                     childBlock._children = new HashSet<BasicBlock>();
 
-                    childBlock._children.Add(targetBlock);
-                    targetBlock._parents.Add(childBlock);
+                    _ = childBlock._children.Add(targetBlock);
+                    _ = targetBlock._parents.Add(childBlock);
                 }
                 else
                 {

--- a/sources/Optimization/CodeAnalysis/Instruction.cs
+++ b/sources/Optimization/CodeAnalysis/Instruction.cs
@@ -275,22 +275,22 @@ namespace TerraFX.Optimization.CodeAnalysis
         {
             var builder = new StringBuilder();
 
-            builder.Append("IL_");
+            _ = builder.Append("IL_");
             var offset = GetOffset();
-            builder.Append(offset.ToString("X4"));
+            _ = builder.Append(offset.ToString("X4"));
 
-            builder.Append(':');
-            builder.Append(' ', 2);
+            _ = builder.Append(':');
+            _ = builder.Append(' ', 2);
 
             var opcodeName = Opcode.Name;
-            builder.Append(opcodeName);
+            _ = builder.Append(opcodeName);
 
             var operand = Operand.ToString();
 
             if (operand != string.Empty)
             {
-                builder.Append(' ', 16 - opcodeName.Length);
-                builder.Append(operand);
+                _ = builder.Append(' ', 16 - opcodeName.Length);
+                _ = builder.Append(operand);
             }
 
             return builder.ToString();


### PR DESCRIPTION
This updates Operand.ToString to handle more kinds, namely member references, so that the output is more correct.

It, notably, doesn't handle decoding type specifications or standalone signatures yet.